### PR TITLE
Fix Terminal Type String

### DIFF
--- a/dist/Frappe.terminal
+++ b/dist/Frappe.terminal
@@ -1434,7 +1434,7 @@
 	<key>ShowDimensionsInTitle</key>
 	<false/>
 	<key>TerminalType</key>
-	<string>xterm-256colour</string>
+	<string>xterm-256color</string>
 	<key>TextBoldColor</key>
 	<data>
 	YnBsaXN0MDDUAQIDBAUGBwpYJHZlcnNpb25ZJGFyY2hpdmVyVCR0b3BYJG9iamVjdHMS

--- a/dist/Latte.terminal
+++ b/dist/Latte.terminal
@@ -1438,7 +1438,7 @@
 	<key>ShowDimensionsInTitle</key>
 	<false/>
 	<key>TerminalType</key>
-	<string>xterm-256colour</string>
+	<string>xterm-256color</string>
 	<key>TextBoldColor</key>
 	<data>
 	YnBsaXN0MDDUAQIDBAUGBwpYJHZlcnNpb25ZJGFyY2hpdmVyVCR0b3BYJG9iamVjdHMS

--- a/dist/Macchiato.terminal
+++ b/dist/Macchiato.terminal
@@ -1434,7 +1434,7 @@
 	<key>ShowDimensionsInTitle</key>
 	<false/>
 	<key>TerminalType</key>
-	<string>xterm-256colour</string>
+	<string>xterm-256color</string>
 	<key>TextBoldColor</key>
 	<data>
 	YnBsaXN0MDDUAQIDBAUGBwpYJHZlcnNpb25ZJGFyY2hpdmVyVCR0b3BYJG9iamVjdHMS

--- a/dist/Mocha.terminal
+++ b/dist/Mocha.terminal
@@ -199,7 +199,7 @@
 	<key>ShowDimensionsInTitle</key>
 	<false/>
 	<key>TerminalType</key>
-	<string>xterm-256colour</string>
+	<string>xterm-256color</string>
 	<key>TextBoldColor</key>
 	<data>
 	YnBsaXN0MDDUAQIDBAUGBwpYJHZlcnNpb25ZJGFyY2hpdmVyVCR0b3BYJG9iamVjdHMS


### PR DESCRIPTION
The term `xterm-256colour` is incorrect and may lead to compatibility issues with terminal emulators and applications that rely on the proper identification of terminal capabilities. Using the correct `xterm-256color` ensures better compatibility and functionality across different environments.